### PR TITLE
Add lite profile scope and get email method

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,39 @@ application.get_connections(totals_only=True)
 }
 ```
 
+## Sign In With LinkedIn (lite profile)
+
+Apps without access to full profile granted by LinkedIn are limited to the sign in with LinkedIn API, check out the [documentation](https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin). Requests to the profile API made by these apps are limited to the lite profile scope, check the [documentation](https://docs.microsoft.com/en-us/linkedin/shared/references/v2/profile/lite-profile?context=linkedin/consumer/context) for more details.
+
+To authenticate with this mode you need to pass the correct permissions to `LinkedInAuthentication`:
+
+```python
+from linkedin_v2.linkedin import PERMISSIONS
+
+authentication = linkedin.LinkedInAuthentication(API_KEY, API_SECRET, RETURN_URL, [PERMISSIONS.LITE_PROFILE, PERMISSIONS.EMAIL_ADDRESS])
+```
+
+With these permissions, `get_profile` returns only the profile's id, first name, and last name. It is possible to retrieve the profile picture by passing a specific projection to `get_profile`.
+
+```python
+from linkedin_v2.linkedin import PROJECTIONS
+
+application.get_profile(params=PROJECTIONS.EXPAND_PROFILE_PICTURE)
+# Be aware that expanding profile pcture results in a very large response json...
+```
+
+In order to fetch the profile's email, an extra call is required:
+
+```python
+application.get_email()
+{
+    "handle": "urn:li:emailAddress:3775708763",
+    "handle~": {
+        "emailAddress": "hsimpson@linkedin.com"
+    }
+}
+```
+
 ## Throttle Limits
 
 LinkedIn API keys are throttled by default. You should take a look at the [Throttle Limits Documentation](http://developer.linkedin.com/documents/throttle-limits) to get more information about it.

--- a/linkedin_v2/__init__.py
+++ b/linkedin_v2/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.9.5'
+__version__ = '0.9.6'
 VERSION = tuple(map(int, __version__.split('.')))

--- a/linkedin_v2/linkedin.py
+++ b/linkedin_v2/linkedin.py
@@ -55,7 +55,7 @@ NETWORK_UPDATES = enum('NetworkUpdate',
                        VIRAL='VIRL')
 
 PROJECTIONS = enum('Projection',
-                   EXPAND_PROFILE_PICTURE={'projection': '(id,profilePicture(displayImage~:playableStreams))'},
+                   EXPAND_PROFILE_PICTURE={'projection': '(id,firstName,lastName,profilePicture(displayImage~:playableStreams))'},
                    EXPAND_EMAIL={'q': 'members', 'projection': '(elements*(handle~))'})
 
 

--- a/linkedin_v2/linkedin.py
+++ b/linkedin_v2/linkedin.py
@@ -20,6 +20,7 @@ __all__ = ['LinkedInAuthentication', 'LinkedInApplication', 'PERMISSIONS']
 
 PERMISSIONS = enum('Permission',
                    COMPANY_ADMIN='rw_company_admin',
+                   LITE_PROFILE='r_liteprofile',
                    BASIC_PROFILE='r_basicprofile',
                    FULL_PROFILE='r_fullprofile',
                    EMAIL_ADDRESS='r_emailaddress',
@@ -77,8 +78,8 @@ class LinkedInAuthentication(object):
     Implements a standard OAuth 2.0 flow that involves redirection for users to
     authorize the application to access account data.
     """
-    AUTHORIZATION_URL = 'https://www.linkedin.com/uas/oauth2/authorization'
-    ACCESS_TOKEN_URL = 'https://www.linkedin.com/uas/oauth2/accessToken'
+    AUTHORIZATION_URL = 'https://www.linkedin.com/oauth/v2/authorization'
+    ACCESS_TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken'
 
     def __init__(self, key, secret, redirect_uri, permissions=None):
         self.key = key
@@ -194,3 +195,9 @@ class LinkedInApplication(object):
         json_response = response.json()
         json_response.update({'numConnections': connections})
         return json_response
+
+    def get_email(self):
+        url = '%s/emailAddress?q=members&projection=(elements*(handle~))' % ENDPOINTS.BASE
+        response = self.make_request('GET', url)
+        raise_for_error(response)
+        return response.json()

--- a/linkedin_v2/linkedin.py
+++ b/linkedin_v2/linkedin.py
@@ -54,6 +54,10 @@ NETWORK_UPDATES = enum('NetworkUpdate',
                        SHARED='SHAR',
                        VIRAL='VIRL')
 
+PROJECTIONS = enum('Projection',
+                   EXPAND_PROFILE_PICTURE={'projection': '(id,profilePicture(displayImage~:playableStreams))'},
+                   EXPAND_EMAIL={'q': 'members', 'projection': '(elements*(handle~))'})
+
 
 class LinkedInDeveloperAuthentication(object):
     """
@@ -197,7 +201,7 @@ class LinkedInApplication(object):
         return json_response
 
     def get_email(self):
-        url = '%s/emailAddress?q=members&projection=(elements*(handle~))' % ENDPOINTS.BASE
-        response = self.make_request('GET', url)
+        url = '%s/emailAddress' % ENDPOINTS.BASE
+        response = self.make_request('GET', url, params=PROJECTIONS.EXPAND_EMAIL)
         raise_for_error(response)
         return response.json()


### PR DESCRIPTION
I Added support to the new [Sign In with LinkedIn API](https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context). It only supports the new `r_liteprofile` scope and requires a separate call in order to fetch the user's email.

I also updated the authorization and token URLs to OAuth V2. 
